### PR TITLE
Fixed the ImportError when importing gxf in gdb from fresh install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
 
-    packages=['gxf'],
+    packages=['gxf', 'gxf.extensions'],
     package_dir={'gxf': 'gxf'},
     include_package_data=True,
     install_requires=requirements,


### PR DESCRIPTION
From a fresh install (python3 setup.py install), when importing inside gdb, I got the following `ImportError`

```
(gdb) python import gxf.extensions
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named 'gxf.extensions'
Error while executing Python code.
```
