### PR TITLE
Arm registers

### DIFF
--- a/gxf/cpu.py
+++ b/gxf/cpu.py
@@ -10,6 +10,13 @@ def get_addrsz():
 
 class Registers(object):
 
+    # ARM specific
+    CPSR_V = 1 << 28
+    CPSR_C = 1 << 29
+    CPSR_Z = 1 << 30
+    CPSR_N = 1 << 31
+
+    # x86(_64) specific
     EFLAGS_CF = 1 << 0
     EFLAGS_PF = 1 << 2
     EFLAGS_AF = 1 << 4
@@ -49,19 +56,28 @@ class Registers(object):
             sl = l.split(None, 2)
             self.regs[sl[0]] = int(sl[1], 0)
 
-        eflags = self.regs["eflags"]
-
         self.flags = {}
 
-        self.flags["CF"] = bool(eflags & self.EFLAGS_CF)
-        self.flags["PF"] = bool(eflags & self.EFLAGS_PF)
-        self.flags["AF"] = bool(eflags & self.EFLAGS_AF)
-        self.flags["ZF"] = bool(eflags & self.EFLAGS_ZF)
-        self.flags["SF"] = bool(eflags & self.EFLAGS_SF)
-        self.flags["TF"] = bool(eflags & self.EFLAGS_TF)
-        self.flags["IF"] = bool(eflags & self.EFLAGS_IF)
-        self.flags["DF"] = bool(eflags & self.EFLAGS_DF)
-        self.flags["OF"] = bool(eflags & self.EFLAGS_OF)
+        if 'eflags' in self.regs: # x86
+            eflags = self.regs["eflags"]
+
+            self.flags["CF"] = bool(eflags & self.EFLAGS_CF)
+            self.flags["PF"] = bool(eflags & self.EFLAGS_PF)
+            self.flags["AF"] = bool(eflags & self.EFLAGS_AF)
+            self.flags["ZF"] = bool(eflags & self.EFLAGS_ZF)
+            self.flags["SF"] = bool(eflags & self.EFLAGS_SF)
+            self.flags["TF"] = bool(eflags & self.EFLAGS_TF)
+            self.flags["IF"] = bool(eflags & self.EFLAGS_IF)
+            self.flags["DF"] = bool(eflags & self.EFLAGS_DF)
+            self.flags["OF"] = bool(eflags & self.EFLAGS_OF)
+        else: # ARM
+            cpsr = self.regs["cpsr"]
+
+            self.flags["N"] = bool(cpsr & self.CPSR_N)
+            self.flags["Z"] = bool(cpsr & self.CPSR_Z)
+            self.flags["V"] = bool(cpsr & self.CPSR_V)
+            self.flags["C"] = bool(cpsr & self.CPSR_C)
+        
 
     def get(self, reg):
         """

--- a/gxf/extensions/registers.py
+++ b/gxf/extensions/registers.py
@@ -39,13 +39,14 @@ class Registers(gxf.DataCommand):
                 continue
 
             if reg == "cpsr":
-                print("%s%s%s%s%s %s" % (
-                        Formattable(((ttype, "%-4s" % reg),(Token.Comment, ": "))),
-                                            ['v','V'][regs.flags['V']],
-                                            ['c','C'][regs.flags['C']],
-                                            ['z','Z'][regs.flags['Z']],
-                                            ['n','N'][regs.flags['N']],
-                                            memory.refchain(val)))
+                print("%sN:%s Z:%s C:%s V:%s %s" % (
+                        Formattable(((ttype, "%-4s" % reg),
+                            (Token.Comment, ": "))),
+                        str(int(regs.flags['V'])),
+                        str(int(regs.flags['C'])),
+                        str(int(regs.flags['Z'])),
+                        str(int(regs.flags['N'])),
+                        memory.refchain(val)))
                 continue
 
 

--- a/gxf/extensions/registers.py
+++ b/gxf/extensions/registers.py
@@ -38,6 +38,17 @@ class Registers(gxf.DataCommand):
             if reg == "eflags" or (len(reg) == 2 and reg[1] == "s"):
                 continue
 
+            if reg == "cpsr":
+                print("%s%s%s%s%s %s" % (
+                        Formattable(((ttype, "%-4s" % reg),(Token.Comment, ": "))),
+                                            ['v','V'][regs.flags['V']],
+                                            ['c','C'][regs.flags['C']],
+                                            ['z','Z'][regs.flags['Z']],
+                                            ['n','N'][regs.flags['N']],
+                                            memory.refchain(val)))
+                continue
+
+
             if reg in tomark:
                 ttype = Token.Name.Builtin
             elif reg in ("rdi", "rsi", "rdx", "rcx", "r8", "r9"):
@@ -51,3 +62,4 @@ class Registers(gxf.DataCommand):
                     Formattable(((ttype, "%-4s" % reg),
                                  (Token.Comment, ": "))),
                     memory.refchain(val)))
+


### PR DESCRIPTION
This adds management and display of the CPSR register instead of the eflags register when using gdb in ARM mode.

It avoids a crash when the "eflags" register does not exist.
And displays CPSR register like this:

```
cpsr: N:0 Z:1 C:1 V:0 0x60030010
```